### PR TITLE
feat(release): publish to PyPI and the official MCP Registry

### DIFF
--- a/.github/workflows/release-metadata.yml
+++ b/.github/workflows/release-metadata.yml
@@ -49,22 +49,23 @@ jobs:
 
       - name: Validate official MCP Registry schema
         run: |
+          set -o pipefail
           check-jsonschema \
             --schemafile https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json \
-            server.json
+            server.json 2>&1 | tee schema-validation.log
 
       - name: Build wheel and source distribution
         run: |
           set -o pipefail
           python -m build 2>&1 | tee package-build.log
 
-      - name: Upload build diagnostics on failure
+      - name: Upload validation diagnostics on failure
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: package-build-diagnostics
-          path: package-build.log
-          if-no-files-found: error
+          name: release-validation-diagnostics
+          path: "*.log"
+          if-no-files-found: warn
           retention-days: 7
 
       - name: Validate distribution metadata

--- a/.github/workflows/release-metadata.yml
+++ b/.github/workflows/release-metadata.yml
@@ -48,7 +48,18 @@ jobs:
         run: python -m pip install --upgrade build twine
 
       - name: Build wheel and source distribution
-        run: python -m build
+        run: |
+          set -o pipefail
+          python -m build 2>&1 | tee package-build.log
+
+      - name: Upload build diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: package-build-diagnostics
+          path: package-build.log
+          if-no-files-found: error
+          retention-days: 7
 
       - name: Validate distribution metadata
         run: python -m twine check dist/*

--- a/.github/workflows/release-metadata.yml
+++ b/.github/workflows/release-metadata.yml
@@ -1,0 +1,92 @@
+name: Release Metadata Validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "PYPI_README.md"
+      - "server.json"
+      - "Dockerfile"
+      - "reversecore_mcp/__init__.py"
+      - "reversecore_mcp/py.typed"
+      - "scripts/check_release_metadata.py"
+      - ".github/workflows/release*.yml"
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "PYPI_README.md"
+      - "server.json"
+      - "Dockerfile"
+      - "reversecore_mcp/__init__.py"
+      - "reversecore_mcp/py.typed"
+      - "scripts/check_release_metadata.py"
+      - ".github/workflows/release*.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate package and registry metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Validate synchronized release metadata
+        run: python scripts/check_release_metadata.py
+
+      - name: Install build validation tools
+        run: python -m pip install --upgrade build twine
+
+      - name: Build wheel and source distribution
+        run: python -m build
+
+      - name: Validate distribution metadata
+        run: python -m twine check dist/*
+
+      - name: Inspect wheel contents
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from zipfile import ZipFile
+
+          wheels = list(Path("dist").glob("*.whl"))
+          if len(wheels) != 1:
+              raise SystemExit(f"expected one wheel, found {len(wheels)}")
+
+          with ZipFile(wheels[0]) as wheel:
+              names = set(wheel.namelist())
+              required = {
+                  "reversecore_mcp/__init__.py",
+                  "reversecore_mcp/server.py",
+                  "reversecore_mcp/py.typed",
+              }
+              missing = required - names
+              if missing:
+                  raise SystemExit(f"wheel is missing required files: {sorted(missing)}")
+
+              if not any(name.startswith("reversecore_mcp/tools/") for name in names):
+                  raise SystemExit("wheel does not contain the MCP tool packages")
+
+              entry_points_name = next(
+                  (name for name in names if name.endswith(".dist-info/entry_points.txt")),
+                  None,
+              )
+              if not entry_points_name:
+                  raise SystemExit("wheel does not contain console entry-point metadata")
+              entry_points = wheel.read(entry_points_name).decode("utf-8")
+              expected = "reversecore-mcp = reversecore_mcp.server:main"
+              if expected not in entry_points:
+                  raise SystemExit(f"missing console entry point: {expected}")
+
+          print(f"validated wheel: {wheels[0]}")
+          PY

--- a/.github/workflows/release-metadata.yml
+++ b/.github/workflows/release-metadata.yml
@@ -44,8 +44,14 @@ jobs:
       - name: Validate synchronized release metadata
         run: python scripts/check_release_metadata.py
 
-      - name: Install build validation tools
-        run: python -m pip install --upgrade build twine
+      - name: Install validation tools
+        run: python -m pip install --upgrade build twine check-jsonschema
+
+      - name: Validate official MCP Registry schema
+        run: |
+          check-jsonschema \
+            --schemafile https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json \
+            server.json
 
       - name: Build wheel and source distribution
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,190 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: ghcr.io/sjkim1127/reversecore_mcp
+  BASE_IMAGE: ghcr.io/sjkim1127/reversecore_mcp/base
+  BASE_TAG: yara4.3.1-r2-6.0.4-r2ghidra-v3
+
+jobs:
+  build:
+    name: Build and validate release artifacts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Verify tag and release metadata
+        run: python scripts/check_release_metadata.py --tag "${GITHUB_REF_NAME}"
+
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Validate distributions
+        run: python -m twine check dist/*
+
+      - name: Upload Python distributions
+        uses: actions/upload-artifact@v6
+        with:
+          name: python-distributions
+          path: dist/
+          if-no-files-found: error
+          retention-days: 14
+
+  publish-pypi:
+    name: Publish package to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/reversecore-mcp/
+    permissions:
+      id-token: write
+    steps:
+      - name: Download Python distributions
+        uses: actions/download-artifact@v7
+        with:
+          name: python-distributions
+          path: dist/
+
+      - name: Publish package using PyPI Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          attestations: true
+
+  publish-oci:
+    name: Publish versioned OCI image
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Verify tag and release metadata
+        run: python scripts/check_release_metadata.py --tag "${GITHUB_REF_NAME}"
+
+      - name: Resolve image tags
+        id: version
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          major_minor="${version%.*}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "major_minor=${major_minor}" >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and publish OCI image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            BASE_IMAGE=${{ env.BASE_IMAGE }}
+            BASE_TAG=${{ env.BASE_TAG }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major_minor }}
+            ${{ env.IMAGE_NAME }}:latest
+          provenance: mode=max
+          sbom: true
+
+  publish-mcp-registry:
+    name: Publish metadata to the official MCP Registry
+    needs: [publish-pypi, publish-oci]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Verify tag and release metadata
+        run: python scripts/check_release_metadata.py --tag "${GITHUB_REF_NAME}"
+
+      - name: Install official MCP publisher
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz"
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/${archive}" \
+            | tar xz mcp-publisher
+          ./mcp-publisher --help >/dev/null
+
+      - name: Authenticate with GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish MCP Registry metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5 6; do
+            if ./mcp-publisher publish; then
+              exit 0
+            fi
+            if [ "${attempt}" -eq 6 ]; then
+              echo "MCP Registry publication failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            delay=$((attempt * 20))
+            echo "Registry or package metadata may still be propagating; retrying in ${delay}s"
+            sleep "${delay}"
+          done
+
+  github-release:
+    name: Create GitHub release
+    needs: [publish-pypi, publish-oci, publish-mcp-registry]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download Python distributions
+        uses: actions/download-artifact@v7
+        with:
+          name: python-distributions
+          path: dist/
+
+      - name: Create release and attach distributions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" dist/* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --verify-tag \
+            --generate-notes \
+            --title "Reversecore MCP ${GITHUB_REF_NAME}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,12 @@ ARG BASE_IMAGE=ghcr.io/sjkim1127/reversecore_mcp/base
 ARG BASE_TAG=latest
 FROM ${BASE_IMAGE}:${BASE_TAG}
 
+LABEL org.opencontainers.image.title="Reversecore MCP" \
+      org.opencontainers.image.description="Security-first MCP server for reverse engineering and malware analysis" \
+      org.opencontainers.image.source="https://github.com/sjkim1127/Reversecore_MCP" \
+      org.opencontainers.image.licenses="MIT" \
+      io.modelcontextprotocol.server.name="io.github.sjkim1127/reversecore-mcp"
+
 # ── Application code ─────────────────────────────────────────────────────────
 # Ordered from least-frequently-changed to most-frequently-changed
 # so Docker layer cache is invalidated as rarely as possible.

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -1,0 +1,80 @@
+# Reversecore MCP
+
+<!-- mcp-name: io.github.sjkim1127/reversecore-mcp -->
+
+**Security-first Model Context Protocol server for reverse engineering, malware analysis, digital forensics, vulnerability research, and SAST.**
+
+Reversecore MCP gives MCP-compatible AI agents structured access to Radare2, r2ghidra, YARA, LIEF, Capstone, angr, Qiling, Volatility3, Scapy, and additional analysis engines. It is designed around explicit workspace boundaries, input validation, non-root containers, and security regression testing.
+
+## Installation
+
+### Full container image — recommended
+
+The container image includes the supported native toolchain and is the most reproducible installation method:
+
+```bash
+docker run -i --rm \
+  -v /absolute/path/to/samples:/app/workspace \
+  -e REVERSECORE_WORKSPACE=/app/workspace \
+  -e MCP_TRANSPORT=stdio \
+  ghcr.io/sjkim1127/reversecore_mcp:2.1.0
+```
+
+### Python package
+
+Install the MCP server and all Python feature extras from PyPI:
+
+```bash
+pip install "reversecore-mcp[full]"
+```
+
+Native programs such as Radare2, YARA, Graphviz, Binwalk, and The Sleuth Kit must be installed separately when using the Python package directly.
+
+Run the stdio server with:
+
+```bash
+MCP_TRANSPORT=stdio \
+REVERSECORE_WORKSPACE=/absolute/path/to/samples \
+reversecore-mcp
+```
+
+## MCP client configuration
+
+```json
+{
+  "mcpServers": {
+    "reversecore": {
+      "command": "reversecore-mcp",
+      "env": {
+        "MCP_TRANSPORT": "stdio",
+        "REVERSECORE_WORKSPACE": "/absolute/path/to/samples"
+      }
+    }
+  }
+}
+```
+
+## Capabilities
+
+- Static analysis, disassembly, decompilation, cross-references, and CFG recovery
+- Malware triage, IOC extraction, YARA scanning, and MITRE ATT&CK mapping
+- Symbolic execution, emulation, fuzzing harness generation, and ROP analysis
+- Memory, disk, network, and host-artifact forensics
+- Python and C/C++ source-code security analysis
+- Structured evidence, session tracking, metrics, and report generation
+
+## Security model
+
+Reversecore MCP processes potentially hostile binaries. Use a dedicated workspace and prefer the hardened container configuration for untrusted samples. The project CI includes dependency auditing, CodeQL, secret scanning, container scanning, path-boundary tests, fuzzing, and network-isolation checks.
+
+Detailed configuration, tool documentation, Docker Compose profiles, and client examples are available in the [GitHub repository](https://github.com/sjkim1127/Reversecore_MCP).
+
+## Registry identity
+
+- MCP Registry name: `io.github.sjkim1127/reversecore-mcp`
+- PyPI package: `reversecore-mcp`
+- OCI image: `ghcr.io/sjkim1127/reversecore_mcp`
+
+## License
+
+MIT

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,83 @@
+# Release and Registry Publishing
+
+Reversecore MCP uses a tag-driven release workflow to publish the same version to:
+
+1. PyPI as `reversecore-mcp`
+2. GitHub Container Registry as `ghcr.io/sjkim1127/reversecore_mcp`
+3. The official MCP Registry as `io.github.sjkim1127/reversecore-mcp`
+4. GitHub Releases with the wheel and source distribution attached
+
+No long-lived package or registry token is stored in GitHub. PyPI and the MCP Registry use GitHub Actions OIDC.
+
+## One-time PyPI setup
+
+The first release requires a PyPI pending Trusted Publisher. In the PyPI account settings, open **Publishing**, add a pending GitHub publisher, and enter:
+
+| Field | Value |
+|---|---|
+| PyPI project name | `reversecore-mcp` |
+| GitHub owner | `sjkim1127` |
+| GitHub repository | `Reversecore_MCP` |
+| Workflow filename | `release.yml` |
+| Environment name | `pypi` |
+
+The pending publisher creates the PyPI project on the first successful workflow run. A pending publisher does not reserve the package name before publication.
+
+In GitHub, create an environment named `pypi`. Deployment reviewers are optional but recommended for production releases.
+
+## MCP Registry authentication
+
+The release workflow runs:
+
+```bash
+mcp-publisher login github-oidc
+mcp-publisher publish
+```
+
+The OIDC identity authorizes the namespace `io.github.sjkim1127/*`. No MCP Registry secret is required.
+
+Ownership of each distribution is verified independently:
+
+- PyPI: `PYPI_README.md` contains `<!-- mcp-name: io.github.sjkim1127/reversecore-mcp -->`
+- OCI: `Dockerfile` contains the `io.modelcontextprotocol.server.name` label
+- Registry metadata: `server.json` uses the same name and version
+
+## Preparing a release
+
+Update all release versions together:
+
+- `pyproject.toml` — `project.version`
+- `reversecore_mcp/__init__.py` — `__version__`
+- `server.json` — root version, PyPI package version, and OCI image tag
+- `PYPI_README.md` — pinned container example when appropriate
+
+Validate locally with Python 3.11 or newer:
+
+```bash
+python scripts/check_release_metadata.py
+python -m pip install --upgrade build twine
+python -m build
+python -m twine check dist/*
+```
+
+The `Release Metadata Validation` workflow performs the same checks on pull requests.
+
+## Publishing
+
+After the release commit is merged into `main`, create and push an annotated version tag that exactly matches `project.version`:
+
+```bash
+git checkout main
+git pull --ff-only
+git tag -a v2.1.0 -m "Reversecore MCP v2.1.0"
+git push origin v2.1.0
+```
+
+The `Publish Release` workflow refuses tags that do not match the checked-in version. It publishes PyPI and OCI artifacts first, waits for both to succeed, publishes MCP Registry metadata, and finally creates the GitHub Release.
+
+## Failure handling
+
+- Do not reuse a version already uploaded to PyPI; package versions are immutable.
+- A failed workflow before PyPI publication can be rerun after correcting account configuration.
+- If PyPI succeeded but a later job failed, fix the downstream problem without changing the package artifact and rerun only when the target permits idempotent publication.
+- The MCP Registry is currently preview infrastructure; temporary propagation failures are retried automatically by the workflow.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "A security-first MCP server that empowers AI agents to perform au
 readme = {file = "PYPI_README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"
 license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     {name = "Kim Seongju"},
 ]
@@ -25,7 +26,6 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
@@ -79,7 +79,6 @@ Changelog = "https://github.com/sjkim1127/Reversecore_MCP/releases"
 reversecore-mcp = "reversecore_mcp.server:main"
 
 [project.optional-dependencies]
-# Binary analysis tools
 analysis = [
     "pefile>=2023.0.0",
     "lief>=0.17.6",
@@ -91,14 +90,12 @@ analysis = [
     "flare-capa>=7.0.0",
 ]
 
-# Visualization (CFG, graphs)
 viz = [
     "graphviz>=0.20.0",
     "networkx>=3.4.2,<3.5",
     "matplotlib>=3.8.0,<3.11",
 ]
 
-# CLI and utilities
 cli = [
     "psutil>=5.9.0",
     "requests>=2.31.0",
@@ -106,35 +103,29 @@ cli = [
     "rich>=13.0.0",
 ]
 
-# Optional dependencies
 magic = [
     "python-magic>=0.4.27",
     "python-magic-bin; sys_platform == 'win32'",
 ]
 
-# HTTP server rate limiting
 http = [
     "slowapi>=0.1.9",
 ]
 
-# Emulation tools
 emulation = [
     "qiling>=1.4.6",
     "python-afl>=0.7.3",
 ]
 
-# Digital forensics tools
 forensics = [
     "volatility3>=2.4.0",
     "scapy>=2.5.0",
 ]
 
-# Full installation (all features)
 full = [
     "reversecore-mcp[analysis,viz,cli,magic,http,emulation,forensics]",
 ]
 
-# Development & Testing dependencies
 dev = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
@@ -161,6 +152,9 @@ include-package-data = true
 where = ["."]
 include = ["reversecore_mcp*"]
 
+[tool.setuptools.package-data]
+reversecore_mcp = ["py.typed"]
+
 [tool.ruff]
 target-version = "py310"
 line-length = 100
@@ -174,18 +168,18 @@ exclude = [
 
 [tool.ruff.lint]
 select = [
-    "E",    # pycodestyle errors
-    "W",    # pycodestyle warnings
-    "F",    # Pyflakes
-    "I",    # isort
-    "B",    # flake8-bugbear
-    "C4",   # flake8-comprehensions
-    "UP",   # pyupgrade
+    "E",
+    "W",
+    "F",
+    "I",
+    "B",
+    "C4",
+    "UP",
 ]
 ignore = [
-    "E501",  # line too long (handled by formatter)
-    "B008",  # do not perform function calls in argument defaults
-    "B904",  # raise without from inside except
+    "E501",
+    "B008",
+    "B904",
 ]
 
 [tool.ruff.lint.isort]
@@ -196,9 +190,9 @@ python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
-no_implicit_optional = true   # Strict: explicit Optional[T] required
-check_untyped_defs = true     # Strict: check untyped function definitions
-disallow_untyped_defs = false # Allow gradual adoption
+no_implicit_optional = true
+check_untyped_defs = true
+disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = [
@@ -212,11 +206,6 @@ ignore_errors = true
 
 [tool.bandit]
 exclude_dirs = ["tests", "htmlcov", ".venv"]
-# B101: assert used
-# B108: hardcoded temp directory (acceptable for binary analysis tools)
-# B110: try_except_pass (used for graceful degradation in analysis)
-# B324: hashlib MD5 (used for file identification, not cryptographic purposes)
-# B404, B603, B607: subprocess warnings (required for binary tools)
 skips = ["B101", "B108", "B110", "B324", "B404", "B603", "B607"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,39 @@
+[build-system]
+requires = ["setuptools>=77", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "reversecore-mcp"
 version = "2.1.0"
 description = "A security-first MCP server that empowers AI agents to perform automated reverse engineering, malware analysis, forensics, vulnerability research, and SAST — powered by Radare2, YARA, LIEF, Capstone, and more."
-readme = "README.md"
+readme = {file = "PYPI_README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"
-license = {text = "MIT"}
+license = "MIT"
+authors = [
+    {name = "Kim Seongju"},
+]
+keywords = [
+    "mcp",
+    "model-context-protocol",
+    "reverse-engineering",
+    "malware-analysis",
+    "digital-forensics",
+    "vulnerability-research",
+    "radare2",
+    "yara",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security",
+    "Typing :: Typed",
+]
 dependencies = [
     # Core MCP server dependencies
     "mcp[cli]>=1.27.0",
@@ -39,6 +68,16 @@ dependencies = [
     "ROPgadget>=7.3",
 ]
 
+[project.urls]
+Homepage = "https://github.com/sjkim1127/Reversecore_MCP"
+Documentation = "https://github.com/sjkim1127/Reversecore_MCP#readme"
+Repository = "https://github.com/sjkim1127/Reversecore_MCP.git"
+Issues = "https://github.com/sjkim1127/Reversecore_MCP/issues"
+Changelog = "https://github.com/sjkim1127/Reversecore_MCP/releases"
+
+[project.scripts]
+reversecore-mcp = "reversecore_mcp.server:main"
+
 [project.optional-dependencies]
 # Binary analysis tools
 analysis = [
@@ -58,7 +97,6 @@ viz = [
     "networkx>=3.4.2,<3.5",
     "matplotlib>=3.8.0,<3.11",
 ]
-
 
 # CLI and utilities
 cli = [
@@ -116,6 +154,13 @@ dev = [
     "pip-tools>=7.4.0",
 ]
 
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["reversecore_mcp*"]
+
 [tool.ruff]
 target-version = "py310"
 line-length = 100
@@ -161,7 +206,7 @@ module = [
     "reversecore_mcp.dashboard.*",
     "reversecore_mcp.core.ghidra",
     "reversecore_mcp.core.ghidra_manager",
-    "reversecore_mcp.core.ghidra_helper"
+    "reversecore_mcp.core.ghidra_helper",
 ]
 ignore_errors = true
 
@@ -197,9 +242,3 @@ exclude_lines = [
     "raise NotImplementedError",
     "if TYPE_CHECKING:",
 ]
-
-[tool.setuptools.packages]
-find = {}
-
-[project.scripts]
-reversecore-mcp = "reversecore_mcp.server:main"

--- a/scripts/check_release_metadata.py
+++ b/scripts/check_release_metadata.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Validate release metadata shared by PyPI, OCI, and the MCP Registry."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+ROOT = Path(__file__).resolve().parents[1]
+MCP_NAME = "io.github.sjkim1127/reversecore-mcp"
+PYPI_NAME = "reversecore-mcp"
+OCI_PREFIX = "ghcr.io/sjkim1127/reversecore_mcp:"
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as file:
+        return tomllib.load(file)
+
+
+def _package_version() -> str:
+    module = ast.parse((ROOT / "reversecore_mcp" / "__init__.py").read_text(encoding="utf-8"))
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "__version__":
+                if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                    return node.value.value
+    raise ValueError("reversecore_mcp.__version__ is missing or is not a string literal")
+
+
+def _project_readme(project: dict[str, Any]) -> Path:
+    readme = project.get("readme")
+    if isinstance(readme, str):
+        return ROOT / readme
+    if isinstance(readme, dict) and isinstance(readme.get("file"), str):
+        return ROOT / readme["file"]
+    raise ValueError("project.readme must reference a file")
+
+
+def validate_release_metadata(tag: str | None = None) -> list[str]:
+    errors: list[str] = []
+    pyproject = _load_toml(ROOT / "pyproject.toml")
+    project = pyproject["project"]
+    version = str(project.get("version", ""))
+
+    if project.get("name") != PYPI_NAME:
+        errors.append(f"project.name must be {PYPI_NAME!r}")
+
+    package_version = _package_version()
+    if package_version != version:
+        errors.append(
+            f"reversecore_mcp.__version__ ({package_version}) does not match pyproject version ({version})"
+        )
+
+    server = json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
+    if server.get("name") != MCP_NAME:
+        errors.append(f"server.json name must be {MCP_NAME!r}")
+    if server.get("version") != version:
+        errors.append(
+            f"server.json version ({server.get('version')}) does not match pyproject version ({version})"
+        )
+
+    packages = {
+        package.get("registryType"): package
+        for package in server.get("packages", [])
+        if isinstance(package, dict)
+    }
+
+    pypi = packages.get("pypi")
+    if not pypi:
+        errors.append("server.json must declare a PyPI package")
+    else:
+        if pypi.get("identifier") != PYPI_NAME:
+            errors.append(f"PyPI identifier must be {PYPI_NAME!r}")
+        if pypi.get("version") != version:
+            errors.append("PyPI package version must match project.version")
+        if pypi.get("transport", {}).get("type") != "stdio":
+            errors.append("PyPI package transport must be stdio")
+
+    oci = packages.get("oci")
+    expected_oci = f"{OCI_PREFIX}{version}"
+    if not oci:
+        errors.append("server.json must declare an OCI package")
+    else:
+        if oci.get("identifier") != expected_oci:
+            errors.append(f"OCI identifier must be {expected_oci!r}")
+        if oci.get("transport", {}).get("type") != "stdio":
+            errors.append("OCI package transport must be stdio")
+
+    readme_path = _project_readme(project)
+    marker = f"<!-- mcp-name: {MCP_NAME} -->"
+    if not readme_path.exists():
+        errors.append(f"project README does not exist: {readme_path.relative_to(ROOT)}")
+    elif marker not in readme_path.read_text(encoding="utf-8"):
+        errors.append(f"{readme_path.name} must contain the MCP ownership marker {marker!r}")
+
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+    label_pattern = re.compile(
+        r'io\.modelcontextprotocol\.server\.name\s*=\s*"?'
+        + re.escape(MCP_NAME)
+        + r'"?'
+    )
+    if not label_pattern.search(dockerfile):
+        errors.append("Dockerfile is missing the MCP Registry ownership label")
+
+    if tag:
+        normalized_tag = tag.removeprefix("refs/tags/")
+        expected_tag = f"v{version}"
+        if normalized_tag != expected_tag:
+            errors.append(f"release tag {normalized_tag!r} must equal {expected_tag!r}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tag",
+        help="Optional release tag to verify, such as v2.1.0 or refs/tags/v2.1.0",
+    )
+    args = parser.parse_args()
+
+    errors = validate_release_metadata(args.tag)
+    if errors:
+        print("Release metadata validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    version = _load_toml(ROOT / "pyproject.toml")["project"]["version"]
+    print(f"Release metadata is consistent for {MCP_NAME} v{version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.sjkim1127/reversecore-mcp",
   "title": "Reversecore MCP",
-  "description": "Security-first MCP server for reverse engineering, malware analysis, digital forensics, vulnerability research, and SAST.",
+  "description": "Security-first MCP server for reverse engineering, malware analysis, forensics, and SAST.",
   "repository": {
     "url": "https://github.com/sjkim1127/Reversecore_MCP",
     "source": "github"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.sjkim1127/reversecore-mcp",
+  "title": "Reversecore MCP",
+  "description": "Security-first MCP server for reverse engineering, malware analysis, digital forensics, vulnerability research, and SAST.",
+  "repository": {
+    "url": "https://github.com/sjkim1127/Reversecore_MCP",
+    "source": "github"
+  },
+  "version": "2.1.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "reversecore-mcp",
+      "version": "2.1.0",
+      "transport": {
+        "type": "stdio"
+      }
+    },
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/sjkim1127/reversecore_mcp:2.1.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- prepare `reversecore-mcp` for PyPI with PEP 621/PEP 639 metadata and a dedicated package README
- add official MCP Registry metadata under `io.github.sjkim1127/reversecore-mcp`
- add OCI ownership labels for GHCR verification
- add synchronized release metadata, official JSON Schema validation, Twine checks, and wheel inspection
- add a tag-driven OIDC release pipeline for PyPI, GHCR, the MCP Registry, and GitHub Releases
- document the one-time PyPI pending Trusted Publisher setup

## Release identity
- PyPI: `reversecore-mcp`
- OCI: `ghcr.io/sjkim1127/reversecore_mcp`
- MCP Registry: `io.github.sjkim1127/reversecore-mcp`

## Verification
Release Metadata Validation run #6 passed:
- synchronized project/package/registry versions
- official MCP Registry `2025-12-11` JSON Schema
- wheel and source distribution build
- Twine metadata validation
- wheel package data, tool modules, typed marker, and CLI entry point

CI/CD Pipeline run #460 passed:
- Python 3.10, 3.11, and 3.12 unit/security suites
- Ruff, formatting, mypy, Bandit, Gitleaks, Hadolint, pip-audit, and CodeQL
- installed-wheel plugin discovery
- Docker build, Trivy, image checks, real binary analysis, and YARA
- MCP Docker integration and in-container smoke suite
- exploit boundary, fuzzing, performance, and network isolation

## One-time external setup after merge
Create the PyPI pending Trusted Publisher with workflow `release.yml` and environment `pypi`. No long-lived PyPI or MCP Registry token is required. The release tag is intentionally not created by this PR.