### PR TITLE
test(e2e): enforce strict MCP and restart recovery checks

### DIFF
--- a/.github/workflows/strict-e2e.yml
+++ b/.github/workflows/strict-e2e.yml
@@ -1,0 +1,206 @@
+name: Strict Docker E2E
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "reversecore_mcp/**"
+      - "scripts/test-mcp-docker-tools.py"
+      - "scripts/test-container-resilience.py"
+      - "scripts/test-e2e-upload-analyze.py"
+      - "Dockerfile"
+      - "Dockerfile.base"
+      - "requirements*.txt"
+      - "pyproject.toml"
+      - ".github/workflows/strict-e2e.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "reversecore_mcp/**"
+      - "scripts/test-mcp-docker-tools.py"
+      - "scripts/test-container-resilience.py"
+      - "scripts/test-e2e-upload-analyze.py"
+      - "Dockerfile"
+      - "Dockerfile.base"
+      - "requirements*.txt"
+      - "pyproject.toml"
+      - ".github/workflows/strict-e2e.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  YARA_VERSION: "4.3.1"
+  RADARE2_VERSION: "6.0.4"
+  BASE_TAG: "yara4.3.1-r2-6.0.4-r2ghidra-v3"
+
+jobs:
+  strict-e2e:
+    name: Strict Docker E2E and Restart Recovery
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Prepare deterministic fixtures
+        run: |
+          set -euo pipefail
+          mkdir -p tests/fixtures/workspace/binaries tests/fixtures/rules artifacts
+          cat > /tmp/reversecore-e2e.c <<'EOF'
+          #include <stdio.h>
+          int main(void) {
+              puts("Reversecore strict E2E fixture");
+              return 0;
+          }
+          EOF
+          gcc -O0 -g -o tests/fixtures/workspace/binaries/hello_x64 /tmp/reversecore-e2e.c
+          cp tests/fixtures/workspace/binaries/hello_x64 \
+             tests/fixtures/workspace/binaries/hello_x64_stripped
+          strip tests/fixtures/workspace/binaries/hello_x64_stripped
+          printf 'Hello World\nReversecore MCP strict E2E\n' \
+            > tests/fixtures/workspace/test_binary.bin
+          cp tests/fixtures/workspace/binaries/hello_x64 tests/fixtures/workspace/sample.elf
+          cat > tests/fixtures/rules/e2e_elf.yar <<'EOF'
+          rule Reversecore_E2E_ELF {
+              strings:
+                  $elf = { 7F 45 4C 46 }
+              condition:
+                  $elf at 0
+          }
+          EOF
+          chmod -R a+rwX tests/fixtures/workspace tests/fixtures/rules
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver: docker
+
+      - name: Build application image
+        run: |
+          set -euo pipefail
+          BASE_IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}/base"
+          echo "BASE_IMAGE=$BASE_IMAGE" >> "$GITHUB_ENV"
+          if ! docker pull "$BASE_IMAGE:${BASE_TAG}"; then
+            docker buildx build \
+              --load \
+              --target base \
+              --build-arg YARA_VERSION="$YARA_VERSION" \
+              --build-arg RADARE2_VERSION="$RADARE2_VERSION" \
+              -t "$BASE_IMAGE:${BASE_TAG}" \
+              -f Dockerfile.base .
+          fi
+          docker build \
+            --build-arg BASE_IMAGE="$BASE_IMAGE" \
+            --build-arg BASE_TAG="$BASE_TAG" \
+            -t reversecore-mcp:strict-e2e .
+
+      - name: Start MCP container
+        run: |
+          set -euo pipefail
+          docker run -d \
+            --name reversecore-strict-e2e \
+            --restart unless-stopped \
+            -p 8765:8000 \
+            -e MCP_TRANSPORT=http \
+            -e MCP_HOST=0.0.0.0 \
+            -e MCP_PORT=8000 \
+            -e LOG_LEVEL=WARNING \
+            -e REVERSECORE_WORKSPACE=/app/workspace \
+            -e REVERSECORE_READ_DIRS=/app/rules \
+            -v "$GITHUB_WORKSPACE/tests/fixtures/workspace:/app/workspace" \
+            -v "$GITHUB_WORKSPACE/tests/fixtures/rules:/app/rules:ro" \
+            reversecore-mcp:strict-e2e
+
+      - name: Wait for readiness
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 45); do
+            code=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+              http://127.0.0.1:8765/health || true)
+            if [ "$code" = "200" ]; then
+              echo "MCP server is ready"
+              exit 0
+            fi
+            echo "Readiness attempt $attempt/45: HTTP ${code:-000}"
+            sleep 2
+          done
+          docker logs reversecore-strict-e2e
+          exit 1
+
+      - name: Install strict probes in container
+        run: |
+          docker cp scripts/test-mcp-docker-tools.py \
+            reversecore-strict-e2e:/tmp/test-mcp-docker-tools.py
+          docker cp scripts/test-container-resilience.py \
+            reversecore-strict-e2e:/tmp/test-container-resilience.py
+          docker cp scripts/test-e2e-upload-analyze.py \
+            reversecore-strict-e2e:/tmp/test-e2e-upload-analyze.py
+
+      - name: Run strict core E2E probes
+        run: |
+          set -euo pipefail
+          docker exec reversecore-strict-e2e python /tmp/test-mcp-docker-tools.py
+          docker exec reversecore-strict-e2e python /tmp/test-container-resilience.py
+          docker exec reversecore-strict-e2e python /tmp/test-e2e-upload-analyze.py
+
+      - name: Restart container and verify recovery
+        run: |
+          set -euo pipefail
+          before=$(docker inspect --format '{{.State.StartedAt}}' reversecore-strict-e2e)
+          docker restart --time 10 reversecore-strict-e2e
+          after=$(docker inspect --format '{{.State.StartedAt}}' reversecore-strict-e2e)
+          if [ "$before" = "$after" ]; then
+            echo "Container start timestamp did not change after restart"
+            exit 1
+          fi
+
+          for attempt in $(seq 1 45); do
+            code=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+              http://127.0.0.1:8765/health || true)
+            if [ "$code" = "200" ]; then
+              echo "MCP server recovered after restart"
+              break
+            fi
+            if [ "$attempt" = "45" ]; then
+              docker logs reversecore-strict-e2e
+              exit 1
+            fi
+            sleep 2
+          done
+
+          docker exec reversecore-strict-e2e python /tmp/test-mcp-docker-tools.py
+          docker exec reversecore-strict-e2e python /tmp/test-container-resilience.py
+          docker exec reversecore-strict-e2e python /tmp/test-e2e-upload-analyze.py
+
+      - name: Collect E2E diagnostics
+        if: failure()
+        run: |
+          mkdir -p artifacts
+          docker logs reversecore-strict-e2e > artifacts/container.log 2>&1 || true
+          docker inspect reversecore-strict-e2e > artifacts/container-inspect.json 2>&1 || true
+          docker ps -a > artifacts/docker-ps.txt 2>&1 || true
+          curl -v http://127.0.0.1:8765/health > artifacts/health.txt 2>&1 || true
+          docker exec reversecore-strict-e2e ps aux > artifacts/processes.txt 2>&1 || true
+
+      - name: Upload E2E diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: strict-e2e-diagnostics
+          path: artifacts/
+          if-no-files-found: warn
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f reversecore-strict-e2e || true

--- a/.github/workflows/strict-e2e.yml
+++ b/.github/workflows/strict-e2e.yml
@@ -150,9 +150,12 @@ jobs:
       - name: Run strict core E2E probes
         run: |
           set -euo pipefail
-          docker exec reversecore-strict-e2e python /tmp/test-mcp-docker-tools.py
-          docker exec reversecore-strict-e2e python /tmp/test-container-resilience.py
-          docker exec reversecore-strict-e2e python /tmp/test-e2e-upload-analyze.py
+          docker exec reversecore-strict-e2e python /tmp/test-mcp-docker-tools.py \
+            2>&1 | tee artifacts/pre-restart-mcp.log
+          docker exec reversecore-strict-e2e python /tmp/test-container-resilience.py \
+            2>&1 | tee artifacts/pre-restart-resilience.log
+          docker exec reversecore-strict-e2e python /tmp/test-e2e-upload-analyze.py \
+            2>&1 | tee artifacts/pre-restart-flow.log
 
       - name: Restart container and verify recovery
         run: |
@@ -179,9 +182,12 @@ jobs:
             sleep 2
           done
 
-          docker exec reversecore-strict-e2e python /tmp/test-mcp-docker-tools.py
-          docker exec reversecore-strict-e2e python /tmp/test-container-resilience.py
-          docker exec reversecore-strict-e2e python /tmp/test-e2e-upload-analyze.py
+          docker exec reversecore-strict-e2e python /tmp/test-mcp-docker-tools.py \
+            2>&1 | tee artifacts/post-restart-mcp.log
+          docker exec reversecore-strict-e2e python /tmp/test-container-resilience.py \
+            2>&1 | tee artifacts/post-restart-resilience.log
+          docker exec reversecore-strict-e2e python /tmp/test-e2e-upload-analyze.py \
+            2>&1 | tee artifacts/post-restart-flow.log
 
       - name: Collect E2E diagnostics
         if: failure()
@@ -190,8 +196,9 @@ jobs:
           docker logs reversecore-strict-e2e > artifacts/container.log 2>&1 || true
           docker inspect reversecore-strict-e2e > artifacts/container-inspect.json 2>&1 || true
           docker ps -a > artifacts/docker-ps.txt 2>&1 || true
+          docker top reversecore-strict-e2e -eo pid,ppid,user,stat,etime,args \
+            > artifacts/processes.txt 2>&1 || true
           curl -v http://127.0.0.1:8765/health > artifacts/health.txt 2>&1 || true
-          docker exec reversecore-strict-e2e ps aux > artifacts/processes.txt 2>&1 || true
 
       - name: Upload E2E diagnostics
         if: failure()

--- a/scripts/test-container-resilience.py
+++ b/scripts/test-container-resilience.py
@@ -1,85 +1,86 @@
 #!/usr/bin/env python3
-"""Test container restart resilience and concurrent request handling."""
+"""Strict resilience checks for a running Reversecore MCP container."""
+
+from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import time
-import urllib.error
 import urllib.request
 
-HEALTH_URL = "http://127.0.0.1:8000/health"
-MCP_SSE_URL = "http://127.0.0.1:8000/mcp/sse"
+HEALTH_URL = os.environ.get("HEALTH_URL", "http://127.0.0.1:8000/health")
+MCP_SSE_URL = os.environ.get("MCP_SERVER_URL", "http://127.0.0.1:8000/mcp/sse")
+HEALTH_REQUESTS = 20
+MCP_SESSIONS = 3
+MAX_HEALTH_LATENCY_SECONDS = 2.0
 
 
-async def concurrent_health_check(count: int = 10) -> tuple[int, int]:
-    """Send N concurrent /health requests using asyncio + urllib."""
-    passed = 0
-    failed = 0
-
-    def fetch() -> bool:
-        try:
-            req = urllib.request.Request(HEALTH_URL)
-            with urllib.request.urlopen(req, timeout=5) as resp:
-                return resp.status == 200
-        except Exception:
-            return False
-
-    loop = asyncio.get_event_loop()
-    tasks = [loop.run_in_executor(None, fetch) for _ in range(count)]
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    for r in results:
-        if r is True:
-            passed += 1
-        else:
-            failed += 1
-
-    return passed, failed
-
-
-def http_get(url: str, timeout: int = 5) -> tuple[int, str]:
-    """Simple synchronous HTTP GET, returns (status_code, body)."""
+def health_request() -> bool:
+    """Return True only for an HTTP 200 health response."""
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
-            return resp.status, resp.read().decode("utf-8", errors="replace")
-    except urllib.error.HTTPError as e:
-        return e.code, ""
-    except Exception as exc:
-        return 0, str(exc)
+        request = urllib.request.Request(HEALTH_URL, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return response.status == 200
+    except Exception:
+        return False
+
+
+async def concurrent_health_checks() -> tuple[int, int]:
+    """Run concurrent health requests without allowing soft failures."""
+    results = await asyncio.gather(
+        *(asyncio.to_thread(health_request) for _ in range(HEALTH_REQUESTS))
+    )
+    passed = sum(1 for result in results if result)
+    return passed, HEALTH_REQUESTS - passed
+
+
+async def mcp_session_probe(index: int) -> int:
+    """Open an independent MCP session and list registered tools."""
+    from mcp import ClientSession
+    from mcp.client.sse import sse_client
+
+    async with sse_client(MCP_SSE_URL) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            count = len(tools.tools)
+            if count < 4:
+                raise AssertionError(f"MCP probe {index} discovered only {count} tools")
+            return count
 
 
 async def test_resilience() -> int:
-    """Run resilience tests against the MCP server."""
-    print("🔄 Testing container resilience...")
+    """Verify concurrent HTTP and MCP requests remain healthy and responsive."""
+    try:
+        print(f"📡 Running {HEALTH_REQUESTS} concurrent health checks...")
+        passed, failed = await concurrent_health_checks()
+        print(f"   health: {passed} passed, {failed} failed")
+        if failed:
+            raise AssertionError(f"{failed} concurrent health request(s) failed")
 
-    # 1. Concurrent health checks
-    print("\n📡 Concurrent health checks (10 requests)...")
-    passed, failed = await concurrent_health_check(10)
-    print(f"   {passed} passed, {failed} failed")
-    if failed > 5:
-        print("❌ Too many concurrent health check failures")
+        print(f"📡 Opening {MCP_SESSIONS} concurrent MCP sessions...")
+        counts = await asyncio.gather(*(mcp_session_probe(i) for i in range(MCP_SESSIONS)))
+        print(f"   MCP tool counts: {counts}")
+        if len(set(counts)) != 1:
+            raise AssertionError(f"Concurrent MCP sessions observed inconsistent registries: {counts}")
+
+        print("⏱️  Measuring health endpoint latency...")
+        started = time.perf_counter()
+        if not await asyncio.to_thread(health_request):
+            raise AssertionError("Final health request failed")
+        elapsed = time.perf_counter() - started
+        print(f"   response time: {elapsed:.3f}s")
+        if elapsed > MAX_HEALTH_LATENCY_SECONDS:
+            raise AssertionError(
+                f"Health endpoint exceeded {MAX_HEALTH_LATENCY_SECONDS:.1f}s: {elapsed:.3f}s"
+            )
+
+        print("✅ Strict container resilience checks passed")
+        return 0
+    except Exception as exc:
+        print(f"❌ Container resilience check failed: {type(exc).__name__}: {exc}")
         return 1
-
-    # 2. SSE endpoint availability
-    print("\n📡 Checking SSE endpoint availability...")
-    status, _ = http_get(MCP_SSE_URL)
-    if status in (200, 405):
-        print(f"   ✅ SSE responds with HTTP {status}")
-    elif status == 0:
-        print("   ⚠️  SSE endpoint unreachable (server may use stdio transport)")
-    else:
-        print(f"   ⚠️  SSE responds with HTTP {status}")
-
-    # 3. Response time check
-    print("\n⏱️  Response time check...")
-    start = time.perf_counter()
-    status, _ = http_get(HEALTH_URL)
-    elapsed = time.perf_counter() - start
-    print(f"   Response time: {elapsed:.3f}s (HTTP {status})")
-    if elapsed > 2.0:
-        print("   ⚠️  Health check is slow (>2s)")
-
-    print("\n✅ Resilience tests complete")
-    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/test-e2e-upload-analyze.py
+++ b/scripts/test-e2e-upload-analyze.py
@@ -1,143 +1,208 @@
 #!/usr/bin/env python3
-"""End-to-end test: upload file → analyze via MCP → verify result."""
+"""Strict end-to-end test for workspace/upload → MCP analysis → verified result."""
+
+from __future__ import annotations
 
 import asyncio
+import json
+import os
 import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import Any
+
+BASE_URL = os.environ.get("MCP_HTTP_BASE_URL", "http://127.0.0.1:8000")
+MCP_SSE_URL = os.environ.get("MCP_SERVER_URL", f"{BASE_URL}/mcp/sse")
+WORKSPACE = Path(os.environ.get("REVERSECORE_WORKSPACE", "/app/workspace")).resolve()
 
 
-def get_text_content(result) -> str:
-    """Extract text from tool result."""
-    text = ""
-    if hasattr(result, "content"):
-        for item in result.content:
-            if hasattr(item, "text"):
-                text += item.text
-    return text[:300]
+def extract_result_text(result: Any) -> str:
+    """Extract textual and structured content from an MCP result."""
+    chunks: list[str] = []
+    for item in getattr(result, "content", []) or []:
+        text = getattr(item, "text", None)
+        if text is not None:
+            chunks.append(str(text))
+
+    structured = getattr(result, "structuredContent", None)
+    if structured is None:
+        structured = getattr(result, "structured_content", None)
+    if structured is not None:
+        chunks.append(json.dumps(structured, sort_keys=True, default=str))
+
+    return "\n".join(chunks).strip()
 
 
-def http_check(url: str, timeout: int = 5) -> int:
-    """Return HTTP status of url, or 0 on connection error."""
+def require_success(result: Any, tool_name: str) -> str:
+    """Require a non-empty MCP result without an explicit error status."""
+    if bool(getattr(result, "isError", False) or getattr(result, "is_error", False)):
+        raise AssertionError(f"{tool_name} returned an MCP error")
+
+    text = extract_result_text(result)
+    if not text:
+        raise AssertionError(f"{tool_name} returned empty content")
+
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
-            return resp.status
-    except urllib.error.HTTPError as e:
-        return e.code
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        payload = None
+
+    if isinstance(payload, dict):
+        status = str(payload.get("status", "")).lower()
+        if payload.get("success") is False or payload.get("ok") is False:
+            raise AssertionError(f"{tool_name} returned a failure payload: {text[:300]}")
+        if status in {"error", "failed", "failure"}:
+            raise AssertionError(f"{tool_name} returned status={status}: {text[:300]}")
+
+    return text
+
+
+def http_status(url: str, timeout: int = 5) -> int:
+    """Return an HTTP status, or zero only when the endpoint is unreachable."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            return response.status
+    except urllib.error.HTTPError as exc:
+        return exc.code
     except Exception:
         return 0
 
 
-async def call_tool(tool_name: str, params: dict) -> str:
-    """Call an MCP tool via SSE and return text content."""
-    MCP_SSE_URL = "http://127.0.0.1:8000/mcp/sse"
-    from mcp import ClientSession as MCPClientSession
-    from mcp.client.sse import sse_client
+def select_elf_fixture() -> Path:
+    """Select a real ELF fixture that must exist before the E2E flow starts."""
+    candidates = (
+        WORKSPACE / "binaries" / "hello_x64",
+        WORKSPACE / "sample.elf",
+        WORKSPACE / "smoke_test_elf",
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(f"No ELF fixture found in: {', '.join(map(str, candidates))}")
 
-    async with sse_client(MCP_SSE_URL) as (read, write):
-        async with MCPClientSession(read, write) as mcp_session:
-            await mcp_session.initialize()
-            result = await mcp_session.call_tool(tool_name, params)
-            return get_text_content(result)
+
+def normalize_workspace_path(raw_path: str) -> Path:
+    """Normalize a server-provided path and enforce workspace containment."""
+    if not raw_path:
+        raise AssertionError("Upload response did not contain a file path")
+
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = WORKSPACE / candidate
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(WORKSPACE)
+    except ValueError as exc:
+        raise AssertionError(f"Upload escaped the workspace: {resolved}") from exc
+    if not resolved.is_file():
+        raise AssertionError(f"Uploaded file does not exist: {resolved}")
+    return resolved
+
+
+def upload_file(path: Path) -> Path:
+    """Upload a fixture via multipart/form-data and return its validated path."""
+    boundary = "----ReversecoreE2EBoundary"
+    body = (
+        (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="file"; filename="{path.name}"\r\n'
+            "Content-Type: application/octet-stream\r\n\r\n"
+        ).encode()
+        + path.read_bytes()
+        + f"\r\n--{boundary}--\r\n".encode()
+    )
+    request = urllib.request.Request(
+        f"{BASE_URL}/upload",
+        data=body,
+        headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        if response.status not in (200, 201):
+            raise AssertionError(f"Upload returned HTTP {response.status}")
+        payload = json.loads(response.read())
+
+    raw_path = payload.get("path") or payload.get("file_path")
+    return normalize_workspace_path(str(raw_path or ""))
+
+
+async def call_tool(session: Any, tool_name: str, params: dict[str, Any]) -> str:
+    """Call a tool with a hard timeout and validate its result."""
+    result = await asyncio.wait_for(session.call_tool(tool_name, params), timeout=30)
+    return require_success(result, tool_name)
 
 
 async def test_e2e() -> int:
-    """Run the full upload → analyze → result flow."""
-    print("🔄 Starting E2E upload → analyze → result test...")
-    passed = 0
-    failed = 0
+    """Run deterministic workspace/upload and analysis flows with strict assertions."""
+    try:
+        from mcp import ClientSession
+        from mcp.client.sse import sse_client
+    except ImportError as exc:
+        print(f"❌ mcp library is required for E2E verification: {exc}")
+        return 1
 
-    # Check if upload endpoint exists
-    upload_status = http_check("http://127.0.0.1:8000/upload")
-    if upload_status not in (200, 201, 405):
-        print(f"  ⚠️  /upload endpoint not available (HTTP {upload_status}), skipping upload tests")
-        # Fall back to direct workspace path tests
-        test_paths = [
-            Path("/app/workspace/smoke_test_elf"),
-            Path("/app/workspace/sample.elf"),
-            Path("/app/workspace/test_binary.bin"),
-        ]
-        for path in test_paths:
-            if not path.exists():
-                continue
-            print(f"\n📁 Testing with {path.name} (direct workspace path)...")
-            try:
-                result = await call_tool("run_file", {"file_path": str(path)})
-                if result:
-                    print(f"  ✅ run_file result: {result[:80]}...")
-                    passed += 1
-                else:
-                    print("  ⚠️  run_file returned empty")
-                    passed += 1
-            except Exception as exc:
-                print(f"  ⚠️  call_tool error (SSE may not be active): {exc}")
-                passed += 1  # Soft pass — SSE transport may not be enabled
+    try:
+        elf_fixture = select_elf_fixture()
+        strings_fixture = WORKSPACE / "test_binary.bin"
+        if not strings_fixture.is_file():
+            raise FileNotFoundError(f"Missing strings fixture: {strings_fixture}")
 
-        print()
-        print("=" * 50)
-        print(f"E2E tests: {passed} passed, {failed} failed")
-        print("=" * 50)
-        return 1 if failed > 0 else 0
+        upload_status = http_status(f"{BASE_URL}/upload")
+        if upload_status == 0:
+            raise ConnectionError("HTTP server is unreachable while probing /upload")
 
-    # Upload endpoint is available — use multipart upload
-    import json
-    import urllib.parse
+        if upload_status in (200, 201, 405):
+            print(f"📤 Upload endpoint detected (HTTP {upload_status}); exercising upload flow")
+            analysis_target = upload_file(elf_fixture)
+            print(f"   uploaded {elf_fixture.name} → {analysis_target}")
+        elif upload_status == 404:
+            print("ℹ️  Upload endpoint is not exposed; exercising strict workspace-path flow")
+            analysis_target = elf_fixture.resolve()
+        else:
+            raise AssertionError(f"Unexpected /upload response: HTTP {upload_status}")
 
-    test_files = {
-        "hello_x64": Path("/app/workspace/binaries/hello_x64"),
-        "sample.elf": Path("/app/workspace/sample.elf"),
-        "test_binary.bin": Path("/app/workspace/test_binary.bin"),
-    }
+        async with sse_client(MCP_SSE_URL) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
 
-    for name, path in test_files.items():
-        if not path.exists():
-            print(f"   ⚠️  {name} not found, skipping")
-            continue
+                tools = await session.list_tools()
+                tool_names = {tool.name for tool in tools.tools}
+                required = {"list_workspace", "run_file", "run_strings"}
+                missing = sorted(required - tool_names)
+                if missing:
+                    raise AssertionError(f"Required E2E tools are missing: {missing}")
 
-        print(f"\n📁 Testing with {name}...")
-        data = path.read_bytes()
+                workspace_text = await call_tool(session, "list_workspace", {})
+                if analysis_target.name.lower() not in workspace_text.lower():
+                    raise AssertionError(
+                        f"list_workspace did not include {analysis_target.name}: {workspace_text[:300]}"
+                    )
+                print(f"✅ list_workspace exposes {analysis_target.name}")
 
-        try:
-            # Step 1: Upload via multipart/form-data using urllib
-            boundary = "----FormBoundary7MA4YWxkTrZu0gW"
-            body = (
-                (
-                    f"--{boundary}\r\n"
-                    f'Content-Disposition: form-data; name="file"; filename="{name}"\r\n'
-                    f"Content-Type: application/octet-stream\r\n\r\n"
-                ).encode()
-                + data
-                + f"\r\n--{boundary}--\r\n".encode()
-            )
+                file_text = await call_tool(
+                    session, "run_file", {"file_path": str(analysis_target)}
+                )
+                if "elf" not in file_text.lower():
+                    raise AssertionError(f"run_file did not identify ELF: {file_text[:300]}")
+                print(f"✅ run_file verified ELF output: {file_text[:160]}")
 
-            req = urllib.request.Request(
-                "http://127.0.0.1:8000/upload",
-                data=body,
-                headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
-                method="POST",
-            )
-            with urllib.request.urlopen(req, timeout=30) as resp:
-                result_json = json.loads(resp.read())
-                uploaded_path = result_json.get("path", result_json.get("file_path", ""))
-                print(f"   📤 Uploaded {name} → {uploaded_path}")
+                strings_text = await call_tool(
+                    session,
+                    "run_strings",
+                    {"file_path": str(strings_fixture), "min_length": 4},
+                )
+                if "hello world" not in strings_text.lower():
+                    raise AssertionError(
+                        f"run_strings did not return known fixture content: {strings_text[:300]}"
+                    )
+                print(f"✅ run_strings verified known content: {strings_text[:160]}")
 
-            # Step 2: Analyze via run_file
-            print("   🔍 run_file...")
-            result = await call_tool("run_file", {"file_path": uploaded_path})
-            print(f"   ✅ run_file result: {result[:80] if result else '(empty)'}...")
-            passed += 1
-
-        except Exception as exc:
-            print(f"   ⚠️  E2E flow error (non-fatal): {exc}")
-            passed += 1  # Soft pass
-
-    print()
-    print("=" * 50)
-    print(f"E2E tests: {passed} passed, {failed} failed")
-    print("=" * 50)
-
-    return 1 if failed > 0 else 0
+        print("🎉 Strict E2E workspace/upload → analyze → result flow passed")
+        return 0
+    except Exception as exc:
+        print(f"❌ Strict E2E flow failed: {type(exc).__name__}: {exc}")
+        return 1
 
 
 if __name__ == "__main__":

--- a/scripts/test-e2e-upload-analyze.py
+++ b/scripts/test-e2e-upload-analyze.py
@@ -83,7 +83,7 @@ def select_elf_fixture() -> Path:
 
 
 def normalize_workspace_path(raw_path: str) -> Path | None:
-    """Return a valid workspace-contained file path, or None for a non-path value."""
+    """Return a valid workspace-contained file path, including renamed uploads."""
     if not raw_path:
         return None
 
@@ -97,6 +97,19 @@ def normalize_workspace_path(raw_path: str) -> Path | None:
             continue
         if resolved.is_file():
             return resolved
+
+    # The upload API intentionally returns only a randomized filename while
+    # storing the file in a workspace subdirectory. Resolve it recursively but
+    # never allow a path outside the configured workspace.
+    basename = candidate.name
+    if basename:
+        matches = [
+            match.resolve()
+            for match in WORKSPACE.rglob(basename)
+            if match.is_file()
+        ]
+        if matches:
+            return max(matches, key=lambda match: match.stat().st_mtime_ns)
     return None
 
 

--- a/scripts/test-e2e-upload-analyze.py
+++ b/scripts/test-e2e-upload-analyze.py
@@ -82,26 +82,43 @@ def select_elf_fixture() -> Path:
     raise FileNotFoundError(f"No ELF fixture found in: {', '.join(map(str, candidates))}")
 
 
-def normalize_workspace_path(raw_path: str) -> Path:
-    """Normalize a server-provided path and enforce workspace containment."""
+def normalize_workspace_path(raw_path: str) -> Path | None:
+    """Return a valid workspace-contained file path, or None for a non-path value."""
     if not raw_path:
-        raise AssertionError("Upload response did not contain a file path")
+        return None
 
     candidate = Path(raw_path)
-    if not candidate.is_absolute():
-        candidate = WORKSPACE / candidate
-    resolved = candidate.resolve()
-    try:
-        resolved.relative_to(WORKSPACE)
-    except ValueError as exc:
-        raise AssertionError(f"Upload escaped the workspace: {resolved}") from exc
-    if not resolved.is_file():
-        raise AssertionError(f"Uploaded file does not exist: {resolved}")
-    return resolved
+    attempts = [candidate] if candidate.is_absolute() else [WORKSPACE / candidate]
+    for attempt in attempts:
+        resolved = attempt.resolve()
+        try:
+            resolved.relative_to(WORKSPACE)
+        except ValueError:
+            continue
+        if resolved.is_file():
+            return resolved
+    return None
+
+
+def iter_upload_path_values(value: Any, parent_key: str = ""):
+    """Yield path-like strings from common top-level or nested upload payload fields."""
+    if isinstance(value, dict):
+        for key, child in value.items():
+            normalized_key = str(key).lower()
+            if isinstance(child, str) and (
+                "path" in normalized_key
+                or normalized_key in {"file", "filename", "name", "saved_as", "location"}
+            ):
+                yield child
+            yield from iter_upload_path_values(child, normalized_key)
+    elif isinstance(value, list):
+        for child in value:
+            yield from iter_upload_path_values(child, parent_key)
 
 
 def upload_file(path: Path) -> Path:
-    """Upload a fixture via multipart/form-data and return its validated path."""
+    """Upload a fixture and resolve the server response to a real workspace file."""
+    existing_matches = {candidate.resolve() for candidate in WORKSPACE.rglob(path.name)}
     boundary = "----ReversecoreE2EBoundary"
     body = (
         (
@@ -123,8 +140,27 @@ def upload_file(path: Path) -> Path:
             raise AssertionError(f"Upload returned HTTP {response.status}")
         payload = json.loads(response.read())
 
-    raw_path = payload.get("path") or payload.get("file_path")
-    return normalize_workspace_path(str(raw_path or ""))
+    print(f"   upload response: {json.dumps(payload, sort_keys=True, default=str)[:600]}")
+
+    for raw_path in iter_upload_path_values(payload):
+        resolved = normalize_workspace_path(raw_path)
+        if resolved is not None:
+            return resolved
+
+    new_matches = [
+        candidate.resolve()
+        for candidate in WORKSPACE.rglob(path.name)
+        if candidate.is_file() and candidate.resolve() not in existing_matches
+    ]
+    if len(new_matches) == 1:
+        return new_matches[0]
+    if len(new_matches) > 1:
+        return max(new_matches, key=lambda candidate: candidate.stat().st_mtime_ns)
+
+    raise AssertionError(
+        "Upload succeeded but no workspace-contained file could be resolved from "
+        f"payload={payload!r}"
+    )
 
 
 async def call_tool(session: Any, tool_name: str, params: dict[str, Any]) -> str:

--- a/scripts/test-mcp-docker-tools.py
+++ b/scripts/test-mcp-docker-tools.py
@@ -1,43 +1,144 @@
 #!/usr/bin/env python3
-"""Test MCP tool registry and invocation inside a running Docker container."""
+"""Strict MCP registry and core-tool verification inside a running container."""
+
+from __future__ import annotations
 
 import asyncio
+import json
+import os
 import sys
+from pathlib import Path
+from typing import Any
+
+MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "http://127.0.0.1:8000/mcp/sse")
+REQUIRED_TOOLS = frozenset(
+    {
+        "get_server_health",
+        "list_workspace",
+        "run_file",
+        "run_strings",
+    }
+)
+
+
+def extract_result_text(result: Any) -> str:
+    """Extract textual or structured content from an MCP call result."""
+    chunks: list[str] = []
+    for item in getattr(result, "content", []) or []:
+        text = getattr(item, "text", None)
+        if text is not None:
+            chunks.append(str(text))
+
+    structured = getattr(result, "structuredContent", None)
+    if structured is None:
+        structured = getattr(result, "structured_content", None)
+    if structured is not None:
+        chunks.append(json.dumps(structured, sort_keys=True, default=str))
+
+    return "\n".join(chunks).strip()
+
+
+def require_success(result: Any, tool_name: str) -> str:
+    """Reject MCP protocol errors, empty responses, and explicit failure payloads."""
+    if bool(getattr(result, "isError", False) or getattr(result, "is_error", False)):
+        raise AssertionError(f"{tool_name} returned an MCP error result")
+
+    text = extract_result_text(result)
+    if not text:
+        raise AssertionError(f"{tool_name} returned no content")
+
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        payload = None
+
+    if isinstance(payload, dict):
+        status = str(payload.get("status", "")).lower()
+        if payload.get("success") is False or payload.get("ok") is False:
+            raise AssertionError(f"{tool_name} returned a failure payload: {text[:300]}")
+        if status in {"error", "failed", "failure"}:
+            raise AssertionError(f"{tool_name} returned status={status}: {text[:300]}")
+
+    return text
+
+
+def select_binary() -> Path:
+    """Select a deterministic ELF fixture available in both CI workflows."""
+    candidates = (
+        Path("/app/workspace/binaries/hello_x64"),
+        Path("/app/workspace/sample.elf"),
+        Path("/app/workspace/smoke_test_elf"),
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(f"No ELF fixture found in: {', '.join(map(str, candidates))}")
 
 
 async def main() -> int:
-    """Connect to local MCP server and verify tools + invocation."""
+    """Connect to the server and prove registry and core tools actually work."""
     try:
         from mcp import ClientSession
         from mcp.client.sse import sse_client
     except ImportError as exc:
-        print(f"⚠️  mcp library not available: {exc}")
-        return 0  # partial success
+        print(f"❌ mcp library is required for E2E verification: {exc}")
+        return 1
 
     try:
-        async with sse_client("http://127.0.0.1:8000/mcp/sse") as (read, write):
+        target = select_binary()
+        strings_target = Path("/app/workspace/test_binary.bin")
+        if not strings_target.is_file():
+            raise FileNotFoundError(f"Missing strings fixture: {strings_target}")
+
+        async with sse_client(MCP_SERVER_URL) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
-                tools = await session.list_tools()
-                print(f"✅ Found {len(tools.tools)} tools")
-                for t in tools.tools[:5]:
-                    print(f"   - {t.name}")
-                if len(tools.tools) == 0:
-                    print("❌ No tools registered")
-                    return 1
 
-                # Call run_file on test binary
-                result = await session.call_tool(
-                    "run_file", {"file_path": "/app/workspace/test_binary.bin"}
+                tools_result = await session.list_tools()
+                tool_names = {tool.name for tool in tools_result.tools}
+                missing = sorted(REQUIRED_TOOLS - tool_names)
+                if missing:
+                    raise AssertionError(f"Required MCP tools are not registered: {missing}")
+                print(f"✅ Registered tools: {len(tool_names)}; required core tools present")
+
+                health_text = require_success(
+                    await session.call_tool("get_server_health", {}), "get_server_health"
                 )
-                print("✅ Tool call succeeded")
-                for content in result.content:
-                    if hasattr(content, "text"):
-                        print(f"   Response: {content.text[:200]}")
-                return 0
+                print(f"✅ get_server_health: {health_text[:160]}")
+
+                workspace_text = require_success(
+                    await session.call_tool("list_workspace", {}), "list_workspace"
+                )
+                if target.name.lower() not in workspace_text.lower():
+                    raise AssertionError(
+                        f"list_workspace did not expose fixture {target.name}: {workspace_text[:300]}"
+                    )
+                print(f"✅ list_workspace contains {target.name}")
+
+                file_text = require_success(
+                    await session.call_tool("run_file", {"file_path": str(target)}), "run_file"
+                )
+                if "elf" not in file_text.lower():
+                    raise AssertionError(f"run_file did not identify ELF content: {file_text[:300]}")
+                print(f"✅ run_file identified ELF: {file_text[:160]}")
+
+                strings_text = require_success(
+                    await session.call_tool(
+                        "run_strings", {"file_path": str(strings_target), "min_length": 4}
+                    ),
+                    "run_strings",
+                )
+                if "hello world" not in strings_text.lower():
+                    raise AssertionError(
+                        f"run_strings did not return the known fixture string: {strings_text[:300]}"
+                    )
+                print(f"✅ run_strings returned known content: {strings_text[:160]}")
+
+        print("🎉 Strict MCP registry and invocation verification passed")
+        return 0
     except Exception as exc:
-        print(f"⚠️  MCP tool test error: {exc}")
-        return 0  # partial success
+        print(f"❌ Strict MCP verification failed: {type(exc).__name__}: {exc}")
+        return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes

- Remove soft-pass behavior from MCP registry, resilience, and upload/analyze E2E probes.
- Require non-empty, non-error MCP results and deterministic fixture assertions for `list_workspace`, `run_file`, `run_strings`, and `get_server_health`.
- Verify 20 concurrent health requests and three concurrent MCP sessions without tolerated failures.
- Exercise the real `/upload` contract, including randomized filenames, while enforcing workspace containment.
- Add a dedicated Docker E2E workflow that runs the probes before and after a real container restart.
- Preserve probe output and upload container logs, inspect state, process state, and health diagnostics on failure.

## Validation

- Strict Docker E2E: passed before and after `docker restart`.
- Existing Docker and MCP integration suite: passed.
- In-container 26-layer smoke test: passed.
- Python 3.10, 3.11, and 3.12 unit/security tests: passed.
- Ruff, Mypy, Bandit, Gitleaks, pip-audit, CodeQL, Trivy, wheel smoke test, and exploit safety gate: passed.