### PR TITLE
fix: restore base-wheel imports and Streamable HTTP transport

### DIFF
--- a/reversecore_mcp/benchmarks/compiler_runner.py
+++ b/reversecore_mcp/benchmarks/compiler_runner.py
@@ -75,6 +75,7 @@ class LiveTargetCompilerRunner:
             Path to compiled executable binary, or None if compilation fails.
         """
         # 1. Resolve Clang compiler executable
+        clang_bin: Path | None
         if clang_path:
             clang_bin = Path(clang_path).expanduser().resolve()
         else:

--- a/reversecore_mcp/resources.py
+++ b/reversecore_mcp/resources.py
@@ -4,7 +4,7 @@ from collections import deque
 from collections.abc import Callable
 from functools import wraps
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from fastmcp import FastMCP
 
@@ -190,14 +190,14 @@ def _get_workspace_path(filename: str) -> str:
     return str(resolved_path)
 
 
-def _register_resource(mcp: FastMCP, uri: str, mime_type: str | None = None) -> Any:
-    """Register resource with FastMCP, gracefully handling mocks without kwargs."""
+def _register_resource(mcp: FastMCP, uri: str, mime_type: str | None = None) -> DecoratorType:
+    """Register resource with FastMCP while preserving the wrapped callable type."""
     try:
         if mime_type is not None:
-            return mcp.resource(uri, mime_type=mime_type)
-        return mcp.resource(uri)
+            return cast(DecoratorType, mcp.resource(uri, mime_type=mime_type))
+        return cast(DecoratorType, mcp.resource(uri))
     except TypeError:
-        return mcp.resource(uri)
+        return cast(DecoratorType, mcp.resource(uri))
 
 
 def register_resources(mcp: FastMCP):

--- a/reversecore_mcp/server.py
+++ b/reversecore_mcp/server.py
@@ -272,7 +272,7 @@ async def _cleanup_old_files():
                     # Check mtime
                     if now - st.st_mtime > retention_seconds:
                         # Only delete files that are clearly temporary or uploaded
-                        # This is a safety measure to avoid deleting user's important files
+                        # This is a safety measure to avoid deleting user's important binary files
                         # Match UUID-prefixed uploads (8 hex chars followed by underscore)
                         is_uuid_upload = bool(re.match(r"^[0-9a-f]{8}_", p.name))
                         # Match temp files (.tmp suffix or .r2_* prefix for radare2)
@@ -439,20 +439,20 @@ def main():
                     )
                     host = "127.0.0.1"
 
-        mcp_app = mcp.http_app(transport="sse")
-
-        # Wrap initialization in FastAPI lifespan
-        @asynccontextmanager
-        async def app_lifespan(app: FastAPI):
-            async with mcp._lifespan_manager():
-                yield
+        # Legacy SSE remains opt-in; HTTP and streamable-http use FastMCP's
+        # default Streamable HTTP transport. The inner path must be "/" because
+        # this ASGI app is mounted by FastAPI at "/mcp" below.
+        if transport == "sse":
+            mcp_app = mcp.http_app(transport="sse")
+        else:
+            mcp_app = mcp.http_app(path="/")
 
         app = FastAPI(
             title="Reversecore_MCP",
             docs_url="/docs",
             redoc_url="/redoc",
             openapi_url="/openapi.json",
-            lifespan=app_lifespan,
+            lifespan=mcp_app.lifespan,
         )
 
         # Container health probes may be external, but all other unauthenticated
@@ -486,6 +486,7 @@ def main():
             allow_credentials=allow_creds,
             allow_methods=["*"],
             allow_headers=["*"],
+            expose_headers=["mcp-session-id"],
         )
 
         # Mount dashboard

--- a/reversecore_mcp/tools/analysis/__init__.py
+++ b/reversecore_mcp/tools/analysis/__init__.py
@@ -1,14 +1,48 @@
 """Static analysis tools package.
 
-Provides a unified AnalysisToolsPlugin that registers all analysis-related tools.
+Provides a unified AnalysisToolsPlugin that registers all analysis-related tools
+while keeping resource-facing modules lazy. This lets the base wheel import the
+server without requiring optional analysis dependencies such as LIEF.
 """
 
-from typing import Any
+from importlib import import_module
+from types import ModuleType
+from typing import Any, Final
 
 from reversecore_mcp.core.logging_config import get_logger
 from reversecore_mcp.core.plugin import Plugin
 
 logger = get_logger(__name__)
+
+
+class _LazyModule(ModuleType):
+    """Module proxy that imports its target on first attribute access."""
+
+    def __init__(self, module_path: str) -> None:
+        super().__init__(module_path)
+        self._module_path = module_path
+
+    def _load(self) -> ModuleType:
+        module = import_module(self._module_path)
+        globals()[self._module_path.rsplit(".", 1)[-1]] = module
+        return module
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._load(), name)
+
+
+# ``reversecore_mcp.resources`` imports these modules at server import time.
+# Keep them as proxies so optional analysis extras are only required when the
+# corresponding resource is actually used.
+_LAZY_RESOURCE_MODULES: Final[dict[str, str]] = {
+    "capa_tools": "reversecore_mcp.tools.analysis.capa_tools",
+    "die_tools": "reversecore_mcp.tools.analysis.die_tools",
+    "lief_tools": "reversecore_mcp.tools.analysis.lief_tools",
+    "static_analysis": "reversecore_mcp.tools.analysis.static_analysis",
+}
+
+for _name, _module_path in _LAZY_RESOURCE_MODULES.items():
+    globals()[_name] = _LazyModule(_module_path)
 
 
 class AnalysisToolsPlugin(Plugin):
@@ -99,4 +133,4 @@ class AnalysisToolsPlugin(Plugin):
         logger.info(f"Registered {self.name} plugin with 27 analysis tools (unified)")
 
 
-__all__ = ["AnalysisToolsPlugin"]
+__all__ = ["AnalysisToolsPlugin", *_LAZY_RESOURCE_MODULES]


### PR DESCRIPTION
## Summary
- keep analysis resource modules lazy so importing the base wheel does not require optional LIEF dependencies
- preserve legacy SSE only when explicitly requested
- use FastMCP Streamable HTTP for `http` / `streamable-http`
- mount the Streamable HTTP app at `/mcp` without producing `/mcp/mcp`
- use `mcp_app.lifespan` so FastMCP transport lifecycle/session state is initialized correctly
- expose `mcp-session-id` through CORS for browser MCP clients

## Validation
- branch is based on current `main` SHA `7367efe9271d61c639935e1d75ad8ea07b9d3877`
- use GitHub Actions on this PR to validate unit tests, lint/security, and wheel smoke/plugin discovery
