### PR TITLE
fix: restore CI transport probes and clear blockers

### DIFF
--- a/scripts/test-container-resilience.py
+++ b/scripts/test-container-resilience.py
@@ -10,7 +10,7 @@ import time
 import urllib.request
 
 HEALTH_URL = os.environ.get("HEALTH_URL", "http://127.0.0.1:8000/health")
-MCP_SSE_URL = os.environ.get("MCP_SERVER_URL", "http://127.0.0.1:8000/mcp/sse")
+MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "http://127.0.0.1:8000/mcp")
 HEALTH_REQUESTS = 20
 MCP_SESSIONS = 3
 MAX_HEALTH_LATENCY_SECONDS = 2.0
@@ -38,9 +38,9 @@ async def concurrent_health_checks() -> tuple[int, int]:
 async def mcp_session_probe(index: int) -> int:
     """Open an independent MCP session and list registered tools."""
     from mcp import ClientSession
-    from mcp.client.sse import sse_client
+    from mcp.client.streamable_http import streamable_http_client
 
-    async with sse_client(MCP_SSE_URL) as (read, write):
+    async with streamable_http_client(MCP_SERVER_URL) as (read, write, _):
         async with ClientSession(read, write) as session:
             await session.initialize()
             tools = await session.list_tools()

--- a/scripts/test-e2e-upload-analyze.py
+++ b/scripts/test-e2e-upload-analyze.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 
 BASE_URL = os.environ.get("MCP_HTTP_BASE_URL", "http://127.0.0.1:8000")
-MCP_SSE_URL = os.environ.get("MCP_SERVER_URL", f"{BASE_URL}/mcp/sse")
+MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", f"{BASE_URL}/mcp")
 WORKSPACE = Path(os.environ.get("REVERSECORE_WORKSPACE", "/app/workspace")).resolve()
 
 
@@ -182,7 +182,7 @@ async def test_e2e() -> int:
     """Run deterministic workspace/upload and analysis flows with strict assertions."""
     try:
         from mcp import ClientSession
-        from mcp.client.sse import sse_client
+        from mcp.client.streamable_http import streamable_http_client
     except ImportError as exc:
         print(f"❌ mcp library is required for E2E verification: {exc}")
         return 1
@@ -207,7 +207,7 @@ async def test_e2e() -> int:
         else:
             raise AssertionError(f"Unexpected /upload response: HTTP {upload_status}")
 
-        async with sse_client(MCP_SSE_URL) as (read, write):
+        async with streamable_http_client(MCP_SERVER_URL) as (read, write, _):
             async with ClientSession(read, write) as session:
                 await session.initialize()
 

--- a/scripts/test-mcp-docker-tools.py
+++ b/scripts/test-mcp-docker-tools.py
@@ -10,7 +10,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "http://127.0.0.1:8000/mcp/sse")
+MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "http://127.0.0.1:8000/mcp")
 REQUIRED_TOOLS = frozenset(
     {
         "get_server_health",
@@ -79,7 +79,7 @@ async def main() -> int:
     """Connect to the server and prove registry and core tools actually work."""
     try:
         from mcp import ClientSession
-        from mcp.client.sse import sse_client
+        from mcp.client.streamable_http import streamable_http_client
     except ImportError as exc:
         print(f"❌ mcp library is required for E2E verification: {exc}")
         return 1
@@ -90,7 +90,7 @@ async def main() -> int:
         if not strings_target.is_file():
             raise FileNotFoundError(f"Missing strings fixture: {strings_target}")
 
-        async with sse_client(MCP_SERVER_URL) as (read, write):
+        async with streamable_http_client(MCP_SERVER_URL) as (read, write, _):
             async with ClientSession(read, write) as session:
                 await session.initialize()
 


### PR DESCRIPTION
## Summary
- migrate strict MCP E2E probes from legacy HTTP+SSE to the server's current Streamable HTTP transport
- use the current `/mcp` endpoint with the pinned MCP 1.28.x client
- continue resolving existing lint/unit CI failures and the newly surfaced Trivy blocker on this branch

## Validation
GitHub Actions on this PR will be used to validate the full CI/CD and Strict Docker E2E paths before merge.